### PR TITLE
Reregister existing framework and support escape of slash in task names

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -284,6 +284,11 @@ Scheduler.prototype.subscribe = function () {
 
             }
 
+        } else {
+            res.on("data",function (chunk) {
+                if (chunk.length > 0)
+                    self.logger.error("Error registering with mesos: " + chunk.toString());
+            });
         }
 
     });
@@ -353,7 +358,8 @@ Scheduler.prototype.subscribe = function () {
     self.logger.info("SUBSCRIBE: " + JSON.stringify(Subscribe));
 
     // Set the Call object
-    var Call = helpers.stringifyEnumsRecursive(new mesos.scheduler.Call(null, "SUBSCRIBE", Subscribe));
+    var Call = helpers.stringifyEnumsRecursive(new mesos.scheduler.Call(
+        self.frameworkId ? new mesos.FrameworkID(self.frameworkId) : null, "SUBSCRIBE", Subscribe));
 
     // Write data to request body
     self.request.write(JSON.stringify(Call));

--- a/lib/schedulerHandlers.js
+++ b/lib/schedulerHandlers.js
@@ -167,7 +167,7 @@ module.exports = {
                     self.logger.debug("commandInfo after adding network info: " + JSON.stringify(helpers.stringifyEnumsRecursive(task.commandInfo)));
 
                     // Get unique taskId
-                    var taskId = self.options.frameworkName + "." + task.name + "." + uuid.v4();
+                    var taskId = self.options.frameworkName + "." + task.name.replace(/\//, "_") + "." + uuid.v4();
 
                     // Set taskId
                     task.taskId = taskId;


### PR DESCRIPTION
I found out that when I tried to reregister an existing framework I received a mismatch of the framework ID in different fields:
`Failed to validate scheduler::Call: 'framework_id' differs from 'subscribe.framework_info.id'`  
Since the subscribe call sets the framework ID to null.  
This sets it to the framework ID given if defined, and prints out the error output from Mesos upon failure to register.  
In addition, since we wanted to use task names with slashes to match the marathon groups we're using, I added an escape of the task name to underscores, like marathon does internally.