### PR TITLE
Static ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The option properties you can specify to create a `Scheduler` are the following:
 * `frameworkFailoverTimeout`: The number of seconds to wait before a framework is considered as `failed` by the leading Mesos master, which will then terminate the existing tasks/executors (default: `604800`).
 * `tasks`: An object (map) with the task info (see below). It's possible to create different (prioritized) tasks, e.g. launching different containers with different instance counts. See the [Docker Scheduler example](https://github.com/tobilg/mesos-framework/blob/master/examples/dockerSchedulerBridgeNetworking.js).
 * `handlers`: An object containing custom handler functions for the `Scheduler` events, where the property name is the uppercase `Event` name.
+* `staticPorts`: A boolean to indicate whether to use fixed ports in the framework or not. Default is `false`.
+* `serialNumberedTasks`: A boolean to indicate whether to add a task serial number to the task name launched in mesos (from the framework's prespective there are always serial numbers in use, they are also part of the task IDs), disabling this is useful for service access with a single mesos DNS name. Defaults to `true`.
 
 A `tasks` sub-object can contain objects with task information:
 
@@ -65,7 +67,7 @@ A `tasks` sub-object can contain objects with task information:
 * `commandInfo`: A [Mesos.CommandInfo](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L397) definition (**mandatory**).
 * `containerInfo`: A [Mesos.ContainerInfo](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L1744) definition.
 * `executorInfo`: A [Mesos.ExecutorInfo](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L460) definition.
-* `resources`: The array of [Mesos.Resource](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L641) definitions (**mandatory**).
+* `resources`: The array of [Mesos.Resource](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L641) definitions (**mandatory**) with an optional fixedPorts number array (included in the general port count).
 * `portMappings`: The array of portMapping objects, each containing a numeric `port` value (for container ports), and a `protocol` string (either `tcp` or `udp`). 
 * `healthChecks`: A [Mesos.HealthCheck](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L302) definition.
 * `labels`: A [Mesos.Labels](https://github.com/apache/mesos/blob/c6e9ce16850f69fda719d4e32be3f2a2e1d80387/include/mesos/v1/mesos.proto#L1845) definition.
@@ -113,6 +115,7 @@ The following events from the Scheduler calls are exposed:
 * `sent_request`: Is emitted when the scheduler has sent a `REQUEST` request to the Master to request new resources.
 * `updated_task`: Is emitted when a task was updated. Contains an object with `taskId`, `executorId` and `state`.  
 * `removed_task`: Is emitted when a task was removed. Contains the `taskId`.
+* `task_launched`: Is emitted when a task moves to the running state, to handle initialization. Contains the task structure.
 
 #### Example
 

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports.Scheduler = require("./lib/scheduler");
 module.exports.Executor = require("./lib/executor");
 module.exports.Mesos = require("./lib/mesos")();
+module.exports.TaskHealthHelper = require("./lib/taskHealthHelper");
 
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -31,13 +31,17 @@ module.exports = {
 
     sortTasksByPriority: function (tasks) {
 
-        //TODO: Change implementation to reflect missing priorities -> Sort by task name instead.
         function prioSort(a,b) {
-            if (a.priority < b.priority)
+            if (a.priority < b.priority) {
                 return -1;
-            if (a.priority > b.priority)
+            }
+            if (a.priority > b.priority) {
                 return 1;
-            return 0;
+            }
+            if (a.name < b.name) {
+                return -1;
+            }
+            return 1;
         }
 
         var tasksArray = [];
@@ -45,6 +49,13 @@ module.exports = {
         Object.getOwnPropertyNames(tasks).forEach(function (task) {
 
             var instances = tasks[task].instances || 1;
+
+            if (tasks[task].resources && tasks[task].resources.staticPorts) {
+                tasks[task].resources.staticPorts.sort();
+                if (!tasks[task].resources.ports || tasks[task].resources.staticPorts.length < tasks[task].resources.ports) {
+                    throw new Error("Static ports must be included in the general port count for the task.");
+                }
+            }
 
             // Add to tasks array
             for (var i = 1; i <= instances; i++) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -35,11 +35,23 @@ function Scheduler (options) {
     self.options.frameworkFailoverTimeout = options.frameworkFailoverTimeout || 604800; // One week
     self.options.masterConnectionTimeout = options.masterConnectionTimeout*1000 || 10000; // Ten seconds
     self.options.killUnknownTasks = options.killUnknownTasks || false;
+    self.options.serialNumberedTasks = (options.serialNumberedTasks === false) ? false : true;
 
     // ZooKeeper
     self.options.useZk = options.useZk || false;
     self.options.zkUrl = options.zkUrl || "master.mesos:2181";
     self.options.zkPrefix = options.zkPrefix || "/dcos-service-";
+
+    // Logging
+    self.logger = helpers.getLogger((options.logging && options.logging.path ? options.logging.path : null), (options.logging && options.logging.fileName ? options.logging.fileName : null), (options.logging && options.logging.level ? options.logging.level : null));
+
+
+    // Port allocation
+    self.options.staticPorts = options.staticPorts || false;
+
+    if (self.options.staticPorts){
+        self.logger.info("Scheduler configured with fixed ports");
+    }
 
     // Master discovery
     self.options.masterUrl = options.masterUrl || "127.0.0.1";
@@ -50,9 +62,6 @@ function Scheduler (options) {
     self.mesosStreamId = null;
     self.lastHeartbeat = null;
     self.zkClient = null;
-
-    // Logging
-    self.logger = helpers.getLogger((options.logging && options.logging.path ? options.logging.path : null), (options.logging && options.logging.fileName ? options.logging.fileName : null), (options.logging && options.logging.level ? options.logging.level : null));
 
     // Tasks
     self.tasks = [];
@@ -300,6 +309,9 @@ Scheduler.prototype.subscribe = function () {
             } else if (event.type === "MESSAGE") {
                 // Emit with usable message object (parsed to ascii)
                 self.emit("message", { agentId: event[event.type.toLocaleLowerCase()].agent_id, executorId: event[event.type.toLocaleLowerCase()].executor_id, data: new Buffer(event[event.type.toLocaleLowerCase()].data, "base64").toString("ascii") });
+            } else if (event.type === "ERROR") {
+                // Emit an actual error object to identify errors from mesos master
+                self.emit("error", new Error("Error received from Mesos master: " + event[event.type.toLocaleLowerCase()].message));
             } else {
                 // Emit original objects for all other types
                 self.emit(event.type.toLocaleLowerCase(), event[event.type.toLocaleLowerCase()]);
@@ -340,6 +352,8 @@ Scheduler.prototype.subscribe = function () {
 
     }
 
+    var handledTimeout = false;
+
     self.httpRequest = http.request(self.requestTemplate, function (res) {
 
         self.logger.info("SUBSCRIBE: Response status: " + res.statusCode);
@@ -368,11 +382,14 @@ Scheduler.prototype.subscribe = function () {
 
                 // Local cache for chunked JSON messages
                 var cache = "";
+                var expectedLength = 0;
 
                 // Watch for data/chunks
                 res.on('data', function (chunk) {
 
-                    var expectedLength = 0;
+                    if (chunk instanceof Buffer) {
+                        chunk = chunk.toString();
+                    }
 
                     if (chunk.indexOf("\n") > -1) {
                         var temp = chunk.split("\n");
@@ -384,6 +401,7 @@ Scheduler.prototype.subscribe = function () {
                             } else {
                                 // Empty cache
                                 cache = "";
+                                expectedLength = 0;
                                 // Handle event
                                 handleEvent(temp[1]);
                             }
@@ -391,13 +409,17 @@ Scheduler.prototype.subscribe = function () {
                             self.emit("error", { message: "Other linebreak count found than expected! Actual count: " + temp.length });
                         }
                     } else {
-                        if (cache.length > 0) {
-                            // Concatenate cached partial data with this chunk
+                        if (cache.length > 0 && (cache.length + chunk.length) >= expectedLength) {
+                            // Concatenate cached partial data with this chunk and handle only when done
                             var eventData = cache + chunk;
                             // Handle event
                             handleEvent(eventData);
                             // Empty cache
                             cache = "";
+                            expectedLength = 0;
+                        } else if (cache.length > 0 && (cache.length + chunk.length) < expectedLength) {
+                            // Concatenate cached data with current chunk, for cases in which the stream buffer is smaller than the data.
+                            cache += chunk;
                         }
                     }
                 });
@@ -405,8 +427,14 @@ Scheduler.prototype.subscribe = function () {
                 res.on('end', function () {
                     self.emit("error", { message: "Long-running connection was closed!" });
                     self.logger.info("Long-running connection was closed!");
-                    // Re-subscribe
-                    self.subscribe();
+                    if (!handledTimeout) {
+                        // Re-subscribe
+                        // We need to remove the stream id from the headers before re-subscribing!
+                        self.mesosStreamId = undefined;
+                        delete self.requestTemplate.headers["mesos-stream-id"];
+                        delete self.requestTemplate.headers["Mesos-Stream-Id"];
+                        self.subscribe();
+                    }
                 });
 
                 res.on('finish', function () {
@@ -440,13 +468,15 @@ Scheduler.prototype.subscribe = function () {
         socket.setTimeout(self.options.masterConnectionTimeout);
         socket.on('timeout', function() {
             self.logger.error("Received a timeout on the long-running Master connection! Will try to re-register the framework scheduler!");
-
-            // We need to remove the stream id from the headers before re-subscribing!
-            self.mesosStreamId = undefined;
-            delete self.requestTemplate.headers["mesos-stream-id"];
+            handledTimeout = true;
+            socket.destroy();
 
             // If we're using Mesos DNS, we can directy re-register, because Mesos DNS will discover the current leader automatically
             if (self.options.masterUrl === "leader.mesos") {
+                // We need to remove the stream id from the headers before re-subscribing!
+                self.mesosStreamId = undefined;
+                delete self.requestTemplate.headers["mesos-stream-id"];
+                delete self.requestTemplate.headers["Mesos-Stream-Id"];
                 self.logger.info("Using Mesos DNS, will re-register to 'leader.mesos'!");
                 // Subscribe
                 self.subscribe();

--- a/lib/schedulerHandlers.js
+++ b/lib/schedulerHandlers.js
@@ -6,6 +6,93 @@ var Mesos = new (require("./mesos"))();
 
 var mesos = Mesos.getMesos();
 
+function searchPortsInRanges(task, offerResources, usableRanges, neededStaticPorts, neededPorts) {
+    var self = this;
+
+    var tempPortRanges = [];
+    var usedPorts = [];
+
+    var begin = 0;
+    var stop = false;
+    var range;
+    var newBegin;
+    var newEnd;
+    var i;
+    var index;
+    var port;
+    while (neededStaticPorts > 0 && !stop && offerResources.portRanges && offerResources.portRanges.length > 0) {
+        range = offerResources.portRanges.splice(0, 1)[0]; // Get first remaining range
+        if (range.begin <= task.resources.staticPorts[begin] && range.end >= task.resources.staticPorts[task.resources.staticPorts.length - 1]) {
+            usableRanges.push(new mesos.Value.Range(range.begin, task.resources.staticPorts[task.resources.staticPorts.length - 1]));
+            newBegin = range.begin;
+            newEnd = range.end;
+            i = begin;
+            while (i < task.resources.staticPorts.length) {
+                port = task.resources.staticPorts[i];
+
+                if (newBegin < port) {
+                    // Re-add range below port
+                    tempPortRanges.push(new mesos.Value.Range(newBegin, port - 1));
+                }
+                newBegin = port + 1;
+                if (newEnd === port) {
+                    newEnd -= 1;
+                }
+                i += 1;
+            }
+            if (newBegin <= newEnd) {
+                tempPortRanges.push(new mesos.Value.Range(newBegin, newEnd));
+            }
+            neededStaticPorts = 0;
+        } else if (range.begin <= task.resources.staticPorts[begin] && range.end >= task.resources.staticPorts[begin]) {
+            usableRanges.push(range);
+            // Count the number of ports that are not served.
+
+            for (i = begin; i < task.resources.staticPorts.length; i++) {
+                if (task.resources.staticPorts[i] > range.end) {
+                    break;
+                }
+            }
+            self.logger.debug(i);
+            self.logger.debug(begin);
+            self.logger.debug(neededStaticPorts);
+
+            neededStaticPorts -= i - begin;
+            newBegin = range.begin;
+            newEnd = range.end;
+            index = begin;
+            while (index < i) {
+                port = task.resources.staticPorts[index];
+
+                if (newBegin < port) {
+                    // Re-add range below port
+                    tempPortRanges.push(new mesos.Value.Range(newBegin, port - 1));
+                }
+                if (newBegin <= port) {
+                    newBegin = port + 1;
+                }
+                if (newEnd === port) {
+                    newEnd -= 1;
+                }
+                index += 1;
+            }
+            if (newBegin <= newEnd) {
+                tempPortRanges.push(new mesos.Value.Range(newBegin, newEnd));
+            }
+            begin = i;
+        } else {
+            stop = true;
+        }
+    }
+    if (neededStaticPorts == 0) {
+        neededPorts -= task.resources.staticPorts.length;
+        usedPorts = task.resources.staticPorts;
+        self.logger.debug("Temp ranges: " + JSON.stringify(tempPortRanges));
+        offerResources.portRanges = offerResources.portRanges.concat(tempPortRanges);
+    }
+    return {usedPorts: usedPorts, neededPorts: neededPorts, neededStaticPorts: neededStaticPorts};
+}
+
 module.exports = {
     "SUBSCRIBED": function (subscribed) {
     },
@@ -17,7 +104,7 @@ module.exports = {
         Offers.offers.forEach(function (offer) {
 
             var toLaunch = [];
-            var isUsed = false;
+            var declinedNoPending = false;
             var offerResources = {
                 cpus: 0,
                 mem: 0,
@@ -32,7 +119,7 @@ module.exports = {
                 // Decline offer
                 self.decline([offer.id], null);
                 // To prevent double decline
-                isUsed = true;
+                declinedNoPending = true;
 
             }
 
@@ -57,11 +144,11 @@ module.exports = {
             // Now, iterate over all tasks that still need to be run
             self.pendingTasks.forEach(function (task) {
 
-                self.logger.debug("pendingTask: " +JSON.stringify(task));
+                self.logger.debug("pendingTask: " + JSON.stringify(task));
 
                 // Match the task resources to the offer resources
                 self.logger.debug("CPUs in offer:" + offerResources.cpus.toString() + " Memory in offer: " + offerResources.mem.toString() + " Port num in offer: " + offerResources.ports.length.toString());
-                if (task.resources.cpus <= offerResources.cpus && task.resources.mem <= offerResources.mem && task.resources.disk <= offerResources.disk && task.resources.ports <= offerResources.ports.length) {
+                if (task.resources.cpus <= offerResources.cpus && task.resources.mem <= offerResources.mem && task.resources.disk <= offerResources.disk && (task.resources.ports <= offerResources.ports.length || (self.options.staticPorts && task.resources.staticPorts && task.resources.staticPorts.length <= offerResources.ports.length))) {
                     self.logger.debug("Offer " + offer.id.value + " has resources left");
 
                     // Environment variables
@@ -83,20 +170,30 @@ module.exports = {
                     }
 
                     if (task.resources.ports > 0) {
-                        var neededPorts = task.resources.ports || 0;
+                        var neededPorts = task.resources.ports;
                         var usableRanges = [];
                         var usedPorts = [];
+                        var neededStaticPorts = task.resources.staticPorts ? task.resources.staticPorts.length : 0;
+
+                        if (self.options.staticPorts && task.resources.staticPorts && task.resources.staticPorts.length > 0) { // Using fixed ports defined in the framework configuration
+                            usedPorts = task.resources.staticPorts;
+                            var __ret = searchPortsInRanges.call(self, task, offerResources, usableRanges, neededStaticPorts, neededPorts);
+                            usedPorts = __ret.usedPorts;
+                            neededPorts = __ret.neededPorts;
+                            neededStaticPorts = __ret.neededStaticPorts;
+                        }
+                        // Using dynamic ports (in addition or instead of fixed ports)
 
                         while (neededPorts > 0 && offerResources.portRanges && offerResources.portRanges.length > 0) {
                             self.logger.debug("portRanges: " + JSON.stringify(offerResources.portRanges));
                             var range = offerResources.portRanges.splice(0, 1)[0]; // Get first remaining range
                             self.logger.debug("actualRange: " + JSON.stringify(range));
-                            var availablePorts = (range.end-range.begin+1);
+                            var availablePorts = (range.end - range.begin + 1);
                             var willUsePorts = (availablePorts >= neededPorts ? neededPorts : availablePorts);
                             // Add to usable ranges
-                            usableRanges.push(new mesos.Value.Range(range.begin, range.begin+willUsePorts-1));
+                            usableRanges.push(new mesos.Value.Range(range.begin, range.begin + willUsePorts - 1));
                             // Add to used ports array
-                            for (var port=range.begin; port <= (range.begin+willUsePorts-1); port++) {
+                            for (var port = range.begin; port <= (range.begin + willUsePorts - 1); port++) {
                                 // Add to used ports
                                 usedPorts.push(port);
                                 // Remove from ports array / reduce available ports by requested task resources
@@ -104,152 +201,158 @@ module.exports = {
                             }
                             // Push range back portRanges if there are ports left
                             if (availablePorts > willUsePorts) {
-                                offerResources.portRanges.push(new mesos.Value.Range(range.begin+willUsePorts, range.end))
+                                offerResources.portRanges.push(new mesos.Value.Range(range.begin + willUsePorts, range.end))
                             }
                             // Decrease needed ports number by used ports
                             neededPorts -= willUsePorts;
                         }
 
-                        self.logger.debug("usableRanges: "+JSON.stringify(usableRanges));
+                        self.logger.debug("usableRanges: " + JSON.stringify(usableRanges));
+                        self.logger.debug(neededPorts);
 
-                        if (neededPorts > 0) {
-                            self.logger.debug("Couldn't find enough ports!");
-                        } else {
-                            // Add to demanded resources
-                            demandedResources.push(helpers.stringifyEnumsRecursive(new mesos.Resource("ports", mesos.Value.Type.RANGES, null, new mesos.Value.Ranges(usableRanges))));
-                            // Check if task is a container task, and if so, it the networking mode is BRIDGE and there are port mappings defined
-                            if (task.containerInfo) {
+                        // Add to demanded resources
+                        demandedResources.push(helpers.stringifyEnumsRecursive(new mesos.Resource("ports", mesos.Value.Type.RANGES, null, new mesos.Value.Ranges(usableRanges))));
+                        // Check if task is a container task, and if so, it the networking mode is BRIDGE and there are port mappings defined
+                        if (task.containerInfo) {
 
-                                self.logger.debug("containerInfo before adding network info: " + JSON.stringify(helpers.stringifyEnumsRecursive(task.containerInfo)));
+                            self.logger.debug("containerInfo before adding network info: " + JSON.stringify(helpers.stringifyEnumsRecursive(task.containerInfo)));
 
-                                // Add the port mappings if needed
-                                if (task.containerInfo.docker.network === "BRIDGE" && task.portMappings && task.portMappings.length > 0) {
-                                    if (usedPorts.length !== task.portMappings.length) {
-                                        self.logger.debug("No match between task's port mapping count and the used/requested port count!");
-                                    } else {
-                                        var portMappings = [],
-                                            counter = 0;
-                                        // Iterate over given port mappings, and create mapping
-                                        task.portMappings.forEach(function (portMapping) {
-                                            portMappings.push(new mesos.ContainerInfo.DockerInfo.PortMapping(usedPorts[counter], portMapping.port, portMapping.protocol));
-                                            counter++;
-                                        });
-
-                                        // Overwrite port mappings
-                                        task.containerInfo.docker.port_mappings = portMappings;
-                                    }
-
-                                }
-
-                                // Add the PORTn environment variables
-                                if (usedPorts.length > 0) {
-                                    var portIndex = 0;
-                                    // Create environment variables for the used ports (schema is "PORT" appended by port index)
-                                    usedPorts.forEach(function (port) {
-                                        envVars.push(new mesos.Environment.Variable("PORT"+portIndex, port.toString()));
-                                        portIndex++;
+                            // Add the port mappings if needed
+                            if (task.containerInfo.docker.network === "BRIDGE" && task.portMappings && task.portMappings.length > 0) {
+                                if (usedPorts.length !== task.portMappings.length) {
+                                    self.logger.debug("No match between task's port mapping count and the used/requested port count!");
+                                } else {
+                                    var portMappings = [],
+                                        counter = 0;
+                                    // Iterate over given port mappings, and create mapping
+                                    task.portMappings.forEach(function (portMapping) {
+                                        portMappings.push(new mesos.ContainerInfo.DockerInfo.PortMapping(usedPorts[counter], portMapping.port, portMapping.protocol));
+                                        counter++;
                                     });
 
+                                    // Overwrite port mappings
+                                    task.containerInfo.docker.port_mappings = portMappings;
                                 }
 
                             }
+
+                            // Add the PORTn environment variables
+                            if (usedPorts.length > 0) {
+                                var portIndex = 0;
+                                // Create environment variables for the used ports (schema is "PORT" appended by port index)
+                                usedPorts.forEach(function (port) {
+                                    envVars.push(new mesos.Environment.Variable("PORT" + portIndex, port.toString()));
+                                    portIndex++;
+                                });
+
+                            }
+
                         }
                     }
+
 
                     // Add HOST
                     envVars.push(new mesos.Environment.Variable("HOST", offer.url.address.ip));
 
-                    //Check if there are already environment variables set
-                    if (task.commandInfo.environment && task.commandInfo.environment.variables && task.commandInfo.environment.variables.length > 0) {
-                        // Merge the arrays
-                        task.commandInfo.environment.variables = task.commandInfo.environment.variables.concat(envVars);
-                    } else { // Just set them
-                        task.commandInfo.environment = new mesos.Environment(envVars);
-                    }
-
-                    self.logger.debug("commandInfo after adding network info: " + JSON.stringify(helpers.stringifyEnumsRecursive(task.commandInfo)));
-
-                    // Get unique taskId
-                    var taskId = self.options.frameworkName + "." + task.name.replace(/\//, "_") + "." + uuid.v4();
-
-                    // Set taskId
-                    task.taskId = taskId;
-
-                    self.logger.debug(JSON.stringify(task));
-
-                    if (task.healthCheck){
-                        var portIndex = task.healthCheck.port ? task.healthCheck.port : 0;
-                        var httpHealthCheck = new mesos.HealthCheck.HTTP(usedPorts[portIndex], task.healthCheck.path, 200);
-                        self.logger.debug("Http healthCheck" + JSON.stringify(httpHealthCheck));
-                        task.healthCheck = new mesos.HealthCheck(httpHealthCheck);
-                    }
-
-                    self.logger.debug(JSON.stringify(task));
-
-                    // Push TaskInfo to toLaunch
-                    toLaunch.push(
-                        new mesos.TaskInfo(
-                            task.name.replace(/\//, "_"), // Task name
-                            new mesos.TaskID(taskId),   // TaskID
-                            offer.agent_id,             // AgentID
-                            demandedResources,          // Resources
-                            (task.executorInfo ? helpers.stringifyEnumsRecursive(task.executorInfo) : null),   // ExecutorInfo
-                            (task.commandInfo ? helpers.stringifyEnumsRecursive(task.commandInfo) : null),     // CommandInfo
-                            (task.containerInfo ? helpers.stringifyEnumsRecursive(task.containerInfo) : null), // ContainerInfo
-                            (task.healthCheck ? helpers.stringifyEnumsRecursive(task.healthCheck) : null),     // HealthCheck
-                            null, // KillPolicy
-                            null, // Data
-                            (task.labels ? helpers.stringifyEnumsRecursive(task.labels) : null), // Labels
-                            null  // DiscoveryInfo
-                        )
-                    );
-
-                    isUsed = true;
-
-                    // Set submit status
-                    task.isSubmitted = true;
-
-                    // Set network runtime info from offer and used ports
-                    if (!task.runtimeInfo) {
-                        task.runtimeInfo = {};
-                        task.runtimeInfo.agentId = offer.agent_id.value || null;
-                        task.runtimeInfo.state = "TASK_STAGING";
-                        task.runtimeInfo.network = {
-                            "hostname": offer.hostname,
-                            "ip": offer.url.address.ip || null,
-                            "ports": usedPorts
-                        };
-
+                    if (neededPorts > 0 || neededStaticPorts > 0) {
+                        self.logger.debug("Couldn't find enough ports!");
                     } else {
-                        task.runtimeInfo.state = "TASK_STAGING";
-                        task.runtimeInfo.agentId = offer.agent_id.value || null;
-                        task.runtimeInfo.network = {
-                            "hostname": offer.hostname,
-                            "ip": offer.url.address.ip || null,
-                            "ports": usedPorts
-                        };
+                        //Check if there are already environment variables set
+                        if (task.commandInfo.environment && task.commandInfo.environment.variables && task.commandInfo.environment.variables.length > 0) {
+                            // Merge the arrays
+                            task.commandInfo.environment.variables = task.commandInfo.environment.variables.concat(envVars);
+                        } else { // Just set them
+                            task.commandInfo.environment = new mesos.Environment(envVars);
+                        }
+
+                        self.logger.debug("commandInfo after adding network info: " + JSON.stringify(helpers.stringifyEnumsRecursive(task.commandInfo)));
+
+                        // Get unique taskId
+                        var taskId = self.options.frameworkName + "." + task.name.replace(/\//, "_") + "." + uuid.v4();
+
+                        // Set taskId
+                        task.taskId = taskId;
+
+                        self.logger.debug(JSON.stringify(task));
+
+                        if (task.healthCheck) {
+                            var portIndex = task.healthCheck.port ? task.healthCheck.port : 0;
+                            var httpHealthCheck = new mesos.HealthCheck.HTTP(usedPorts[portIndex], task.healthCheck.path, 200);
+                            self.logger.debug("Http healthCheck" + JSON.stringify(httpHealthCheck));
+                            task.healthCheck = new mesos.HealthCheck(httpHealthCheck);
+                        }
+
+                        task.mesosName = task.name.replace(/\//, "_");
+
+                        if (!self.options.serialNumberedTasks) {
+                            task.mesosName = task.mesosName.replace(/-[0-9]+$/,""); // removing serial from mesos task info
+                        }
+                        self.logger.debug("Mesos task name: " + task.mesosName + " is using serialNumberedTasks: " + self.options.serialNumberedTasks.toString());
+                        // Push TaskInfo to toLaunch
+                        toLaunch.push(
+                            new mesos.TaskInfo(
+                                task.mesosName, // Task name
+                                new mesos.TaskID(taskId),   // TaskID
+                                offer.agent_id,             // AgentID
+                                demandedResources,          // Resources
+                                (task.executorInfo ? task.executorInfo : null),   // ExecutorInfo
+                                (task.commandInfo ? task.commandInfo : null),     // CommandInfo
+                                (task.containerInfo ? task.containerInfo : null), // ContainerInfo
+                                (task.healthCheck ? helpers.stringifyEnumsRecursive(task.healthCheck) : null),     // HealthCheck
+                                null, // KillPolicy
+                                null, // Data
+                                (task.labels ? task.labels : null), // Labels
+                                null  // DiscoveryInfo
+                            )
+                        );
+
+                        // Set submit status
+                        task.isSubmitted = true;
+
+                        // Set network runtime info from offer and used ports
+                        if (!task.runtimeInfo) {
+                            task.runtimeInfo = {};
+                            task.runtimeInfo.agentId = offer.agent_id.value || null;
+                            task.runtimeInfo.state = "TASK_STAGING";
+                            task.runtimeInfo.network = {
+                                "hostname": offer.hostname,
+                                "ip": offer.url.address.ip || null,
+                                "ports": usedPorts
+                            };
+
+                        } else {
+                            task.runtimeInfo.state = "TASK_STAGING";
+                            task.runtimeInfo.agentId = offer.agent_id.value || null;
+                            task.runtimeInfo.network = {
+                                "hostname": offer.hostname,
+                                "ip": offer.url.address.ip || null,
+                                "ports": usedPorts
+                            };
+                        }
+
+                        self.logger.debug("task details for taskId " + task.taskId + ": " + JSON.stringify(task));
+
+                        self.logger.debug("TaskInfo before launch: " + JSON.stringify(helpers.stringifyEnumsRecursive(toLaunch[toLaunch.length - 1])));
+
+                        // Remove from pendingTasks!
+                        self.pendingTasks.splice(self.pendingTasks.indexOf(task), 1);
+
+                        self.logger.debug("pendingTask length: " + self.pendingTasks.length);
+
+                        // Add to launched tasks
+                        self.launchedTasks.push(task);
+
+                        // Save to ZooKeeper
+                        if (self.options.useZk && self.taskHelper) {
+                            self.taskHelper.saveTask(task);
+                        }
+
+                        self.logger.debug("launchedTasks length: " + self.launchedTasks.length);
+
+                        declinedNoPending = true;
                     }
 
-                    self.logger.debug("task details for taskId " + task.taskId + ": " + JSON.stringify(task));
-
-                    self.logger.debug("TaskInfo before launch: " + JSON.stringify(helpers.stringifyEnumsRecursive(toLaunch[toLaunch.length-1])));
-
-                    // Remove from pendingTasks!
-                    self.pendingTasks.splice(self.pendingTasks.indexOf(task), 1);
-
-                    self.logger.debug("pendingTask length: " + self.pendingTasks.length);
-
-                    // Add to launched tasks
-                    self.launchedTasks.push(task);
-
-                    // Save to ZooKeeper
-                    if (self.options.useZk && self.taskHelper) {
-                        self.taskHelper.saveTask(task);
-                    }
-
-                    self.logger.debug("launchedTasks length: " + self.launchedTasks.length);
-
-                    self.logger.debug("Offer " + offer.id.value + ": Available resources: " + offerResources.cpus + " - " + offerResources.mem + " - " + offerResources.disk + " - "+ offerResources.ports.length)
+                    self.logger.debug("Offer " + offer.id.value + ": Available resources: " + offerResources.cpus + " - " + offerResources.mem + " - " + offerResources.disk + " - " + offerResources.ports.length)
 
                 } else {
                     self.logger.debug("Offer " + offer.id.value + " has no fitting resources left");
@@ -274,11 +377,10 @@ module.exports = {
                     // Trigger acceptance
                     self.accept([offer.id], Operations, null);
                 });
-
             }
 
             // Decline offer if not used
-            if (!isUsed) {
+            if (!declinedNoPending) {
 
                 process.nextTick(function () {
                     self.logger.debug("Declining Offer " + offer.id.value);
@@ -287,7 +389,6 @@ module.exports = {
                 });
 
             }
-
         });
 
     },
@@ -310,14 +411,25 @@ module.exports = {
                 self.logger.debug("TaskId " + status.task_id.value + " got restartable state: " + status.state);
                 // Track launchedTasks array index
                 var foundIndex = 0;
+                var tempLaunchedTasks = self.launchedTasks.slice();
                 // Restart task by splicing it from the launchedTasks array, and afterwards putting it in the pendingTasks array after a cleanup
-                self.launchedTasks.forEach(function (task) {
+                tempLaunchedTasks.forEach(function (task) {
                     if (status.task_id.value === task.taskId) {
+                        // Check if task was restarted, it means it was already replaced.
+                        if (task.runtimeInfo.restarting) {
+                            // Remove task from launchedTasks array
+                            self.launchedTasks.splice(self.launchedTasks.indexOf(task), 1);
+                            self.logger.debug("TaskId " + status.task_id.value + " was killed and removed from the launchedTasks");
+
+                            if (self.options.useZk) {
+                                self.taskHelper.deleteTask(status.task_id.value);
+                            }
+                            return;
+                        }
                         // Splice from launchedTasks if found
                         var taskToRestart = helpers.cloneDeep(self.launchedTasks.splice(foundIndex, 1)[0]);
                         self.logger.debug("taskToRestart before cleaning: " + JSON.stringify(taskToRestart));
 
-                        // TODO: Check
                         if (self.options.useZk) {
                             self.taskHelper.deleteTask(taskToRestart.taskId);
                         }
@@ -334,7 +446,7 @@ module.exports = {
                             // Iterate over all environment variables
                             taskToRestart.commandInfo.environment.variables.forEach(function (variable) {
                                 // Check if variable name contains either HOST or PORT -> Set by this framework when starting a task
-                                if (variable.name.match(/HOST/g) === null && variable.name.match(/PORT/g) === null) {
+                                if (variable.name.match(/^HOST$/g) === null && variable.name.match(/^PORT[0-9]+$/g) === null) {
                                     // Add all non-matching (user-defined) environment variables
                                     usableVariables.push(variable);
                                 }
@@ -357,14 +469,14 @@ module.exports = {
                 var index = 0;
                 var match = false;
                 // Iterate over launched tasks
-                for (index = 0;index < self.launchedTasks.length;index++) {
+                for (index = 0; index < self.launchedTasks.length; index++) {
                     var task = self.launchedTasks[index];
                     self.logger.debug("task id is " + task.taskId);
                     if (status.task_id.value === task.taskId) {
                         self.logger.debug("Matched TaskId " + status.task_id.value);
                         match = true;
                         // Check if state is TASK_KILLED and TASK_KILLED is not in restartable states array, same for TASK_FINISHED
-                        if ((self.options.restartStates.indexOf("TASK_KILLED") === -1 && status.state === "TASK_KILLED") || (self.options.restartStates.indexOf("TASK_FINISHED") === -1 && status.state === "TASK_FINISHED")) {
+                        if ((self.options.restartStates.indexOf("TASK_KILLED") === -1 && status.state === "TASK_KILLED") || (self.options.restartStates.indexOf("TASK_FINISHED") === -1 && status.state === "TASK_FINISHED") || (task.runtimeInfo.restarting)) {
                             // Remove task from launchedTasks array
                             self.launchedTasks.splice(index, 1);
                             self.logger.debug("TaskId " + status.task_id.value + " was killed and removed from the launchedTasks");
@@ -381,7 +493,7 @@ module.exports = {
                             if (Object.getOwnPropertyNames(task.runtimeInfo).length > 0) {
                                 network = helpers.cloneDeep(task.runtimeInfo.network);
                                 if (!status.executor_id || !status.executor_id.value) {
-                                    status.executor_id = { value: task.runtimeInfo.executorId };
+                                    status.executor_id = {value: task.runtimeInfo.executorId};
                                 }
                                 // Check if we need to emit an event
                                 if (task.runtimeInfo.state === "TASK_STAGING" && status.state === "TASK_RUNNING") {

--- a/lib/taskHealthHelper.js
+++ b/lib/taskHealthHelper.js
@@ -1,0 +1,136 @@
+"use strict";
+
+var http = require("http");
+
+/**
+ * Represents a TaskHealthHelper object
+ * @constructor
+ * @param {object} scheduler - The scheduler object.
+ * @param {object} options - The option map object.
+ */
+function TaskHealthHelper(scheduler, options) {
+    if (!(this instanceof TaskHealthHelper)) {
+        return new TaskHealthHelper(scheduler, options);
+    }
+
+    var self = this;
+
+    self.scheduler = scheduler;
+    self.logger = scheduler.logger;
+    self.options = {};
+    self.options.interval = options.interval || 30;
+    self.options.graceCount = options.graceCount || 4;
+    self.options.portIndex = options.portIndex || 0;
+    self.options.errorEvent = options.errorEvent || "task_unhealthy";
+    self.options.additionalProperties = options.additionalProperties || [];
+    self.options.taskNameFilter = options.taskNameFilter || null;
+    self.options.statusCodes = options.statusCodes || [200];
+    self.options.propertyPrefix = options.propertyPrefix || "";
+    if (options.url) {
+        self.options.url = options.url;
+    } else {
+        throw new Error("Must set URL");
+    }
+
+    self.healthRequestCreate = function (host, port) {
+        return {
+            "host": host,
+            "port": port,
+            "path": options.url,
+            "method": "GET",
+            headers: {}
+        };
+    };
+
+    self.checkRunningInstances = function () {
+
+        self.logger.debug("Running periodic healthcheck" + (self.options.propertyPrefix.length ? ", prefix: " + self.options.propertyPrefix : ""));
+
+        self.scheduler.launchedTasks.forEach(function (task) {
+            self.checkInstance.call(self, task);
+        });
+    };
+}
+
+TaskHealthHelper.prototype.taskFilter = function (name) {
+    var self = this;
+    if (self.options.taskNameFilter) {
+        return name.match(self.options.taskNameFilter) !== null;
+    }
+    return true;
+};
+
+TaskHealthHelper.prototype.setCheckFailed = function (task) {
+
+    var self = this;
+
+    if (task.runtimeInfo[self.options.propertyPrefix + "checkFailCount"] === undefined) {
+        task.runtimeInfo[self.options.propertyPrefix + "checkFailCount"] = 0;
+    }
+    task.runtimeInfo[self.options.propertyPrefix + "checkFailCount"] += 1;
+    self.logger.debug("Task found unhealthy" + (self.options.propertyPrefix.length ? ", prefix: " + self.options.propertyPrefix : ""));
+    if (task.runtimeInfo[self.options.propertyPrefix + "checkFailCount"] === self.options.graceCount) {
+        self.logger.debug("Task marked unhealthy" + (self.options.propertyPrefix.length ? ", prefix: " + self.options.propertyPrefix : ""));
+        task.runtimeInfo[self.options.propertyPrefix + "healthy"] = false;
+        self.options.additionalProperties.forEach(function (property) {
+            if (property.setUnhealthy) {
+                var value = false;
+                if (property.inverse) {
+                    value = !value;
+                }
+                task.runtimeInfo[property.name] = value;
+            }
+        });
+        self.scheduler.emit(self.options.errorEvent, task);
+    } else if (task.runtimeInfo[self.options.propertyPrefix + "healthy"] === false) {
+        self.scheduler.emit(self.options.errorEvent, task);
+    }
+};
+
+TaskHealthHelper.prototype.checkInstance = function (task) {
+
+    var self = this;
+
+    if (task.runtimeInfo && task.runtimeInfo.state === "TASK_RUNNING" && self.taskFilter(task.name)) {
+        if (task.runtimeInfo.network && task.runtimeInfo.network.hostname && task.runtimeInfo.network.ports && task.runtimeInfo.network.ports[self.options.portIndex]) {
+            var req = http.request(self.healthRequestCreate(task.runtimeInfo.network.hostname, task.runtimeInfo.network.ports[self.options.portIndex]), function (res) {
+                if (self.options.statusCodes.indexOf(res.statusCode) > -1) {
+                    task.runtimeInfo[self.options.propertyPrefix + "checkFailCount"] = 0;
+                    task.runtimeInfo[self.options.propertyPrefix + "healthy"] = true;
+                    self.options.additionalProperties.forEach(function (property) {
+                        var value = true;
+                        if (property.inverse) {
+                            value = !value;
+                        }
+                        task.runtimeInfo[property.name] = value;
+                    });
+                } else {
+                    self.setCheckFailed.call(self, task);
+                }
+                res.resume();
+            });
+            req.on("error", function (error) {
+                self.logger.error("Error checking task health:" + JSON.stringify(error) + (self.options.propertyPrefix.length ? ", prefix: " + self.options.propertyPrefix : ""));
+                self.setCheckFailed.call(self, task);
+            });
+            req.end();
+        }
+    }
+};
+
+TaskHealthHelper.prototype.stopHealthCheck = function () {
+    var self = this;
+
+    if (self.interval) {
+        clearInterval(this.interval);
+        self.interval = null;
+    }
+}
+
+TaskHealthHelper.prototype.setupHealthCheck = function () {
+    var self = this;
+
+    self.interval = setInterval(self.checkRunningInstances, self.options.interval * 1000);
+};
+
+module.exports = TaskHealthHelper;

--- a/lib/taskHelper.js
+++ b/lib/taskHelper.js
@@ -53,7 +53,7 @@ TaskHelper.prototype.loadTasks = function() {
                         var pendingTask = pending[i];
                         self.logger.debug("Pending task: \"" + JSON.stringify(pendingTask) + "\"");
                         if (pendingTask.name === task.name) {
-                            if (task.runtimeInfo && task.runtimeInfo.agentId && (task.state === "TASK_RUNNING" || task.state === "TASK_STAGING")) {
+                            if (task.runtimeInfo && task.runtimeInfo.agentId && (task.runtimeInfo.state === "TASK_RUNNING" || task.runtimeInfo.state === "TASK_STAGING")) {
                                 self.scheduler.launchedTasks.push(task);
                                 pending.splice(i, 1);
                                 self.scheduler.reconcileTasks.push(task);

--- a/lib/taskHelper.js
+++ b/lib/taskHelper.js
@@ -26,7 +26,7 @@ TaskHelper.prototype.loadTasks = function() {
             self.logger.error("Could not load task information.");
             // We're ready to subscribe
             self.scheduler.emit("ready");
-        } else if (children) {
+        } else if (children && children.length) {
             var childStates = {};
             children.forEach(function (child) {
                 self.zkClient.getData(self.zkServicePath + "/tasks/" + child, function (error, data, stat) {
@@ -52,8 +52,8 @@ TaskHelper.prototype.loadTasks = function() {
                     for (i = 0;i < pending.length; i++) {
                         var pendingTask = pending[i];
                         self.logger.debug("Pending task: \"" + JSON.stringify(pendingTask) + "\"");
-                        if (pendingTask.name == task.name) {
-                            if (task.runtimeInfo && task.runtimeInfo.agentId) {
+                        if (pendingTask.name === task.name) {
+                            if (task.runtimeInfo && task.runtimeInfo.agentId && (task.state === "TASK_RUNNING" || task.state === "TASK_STAGING")) {
                                 self.scheduler.launchedTasks.push(task);
                                 pending.splice(i, 1);
                                 self.scheduler.reconcileTasks.push(task);
@@ -71,19 +71,16 @@ TaskHelper.prototype.loadTasks = function() {
                     self.scheduler.pendingTasks = pending;
                     childStates[child] = {'loaded': true};
                     self.logger.debug("childStates length " + Object.keys(childStates).length.toString() + " children.length " + children.length.toString());
-                    if (Object.keys(childStates).length == children.length) {
+                    if (Object.keys(childStates).length === children.length) {
                         // We're ready to subscribe
                         self.scheduler.emit("ready");
                     }
                 });
             });
-            if (children.length == 0) {
-                // We're ready to subscribe
-                self.scheduler.emit("ready");
-            }
+        } else {
+            // We're ready to subscribe - no tasks
+            self.scheduler.emit("ready");
         }
-
-        
     });
 };
 

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -42,7 +42,7 @@ describe("helpers", function() {
             expect(tasks).to.be.an("array");
             expect(tasks).to.have.lengthOf(4);
         });
-        it.skip("Sort the task array with 3 submitted tasks with priority and out of order names", function () {
+        it("Sort the task array with 3 submitted tasks with priority and out of order names", function () {
             var tasks = helpers.sortTasksByPriority({
                     task3:{isSubmitted:true, priority:1},
                     task2:{isSubmitted:true, priority:2},
@@ -51,6 +51,32 @@ describe("helpers", function() {
             expect(tasks).to.be.an("array");
             expect(tasks).to.have.lengthOf(3);
             expect(tasks[0].name).to.equal("task1-1");
+        });
+        it("Sort the task array with static ports out of order", function () {
+            var tasks = helpers.sortTasksByPriority({
+                task1: {isSubmitted: true, priority: 1, resources: {ports: 2, staticPorts: [9001, 8000]}}
+            });
+            expect(tasks).to.be.an("array");
+            expect(tasks).to.have.lengthOf(1);
+            expect(tasks[0].resources.staticPorts[0]).to.equal(8000);
+        });
+        it("Sort the task array with static ports out of order - no ports set", function () {
+            try {
+                helpers.sortTasksByPriority({
+                    task1: {isSubmitted: true, priority: 1, resources: {staticPorts: [9001, 8000]}}
+                });
+            } catch (error) {
+                expect(error).to.be.an.error;
+            }
+        });
+        it("Sort the task array with static ports out of order - not enough ports set", function () {
+            try {
+                helpers.sortTasksByPriority({
+                    task1: {isSubmitted: true, priority: 1, resources: {ports: 1, staticPorts: [9001, 8000]}}
+                });
+            } catch (error) {
+                expect(error).to.be.an.error;
+            }
         });
     });
     describe("Enum enumeration", function () {

--- a/tests/schedulerHandlers.test.js
+++ b/tests/schedulerHandlers.test.js
@@ -22,7 +22,7 @@ describe("Offers handlers tests", function () {
         // Inherit from EventEmitter
         EventEmitter.call(this);
         return this;
-    };
+    }
 
     var scheduler = new SchedulerStub();
 
@@ -37,52 +37,7 @@ describe("Offers handlers tests", function () {
         "fragment": ""
     };
 
-    var offers = {
-        "type": "OFFERS",
-        "offers": [
-            {
-                "id": {"value": "12214-23523-O235235"},
-                "framework_id": {"value": "12124-235325-32425"},
-                "agent_id": {"value": "12325-23523-S23523"},
-                "hostname": "agent.host",
-                "url": Url,
-                "resources": [
-                    {
-                        "name": "cpus",
-                        "type": "SCALAR",
-                        "scalar": {"value": 1.1},
-                        "role": "*"
-                    },
-                    {
-                        "name": "mem",
-                        "role": "*",
-                        "type": "SCALAR",
-                        "scalar": {"value": 256}
-                    },
-                    {
-                        "name": "disk",
-                        "type": "SCALAR",
-                        "scalar": {
-                            "value": 10000
-                        }
-                    },
-                    {
-                        "name": "ports",
-                        "role": "*",
-                        "type": "RANGES",
-                        "ranges": {
-                            "range": [
-                                {
-                                    "begin": 8080,
-                                    "end": 8090
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        ]
-    };
+    var offers;
 
     var ContainerInfo = new Mesos.ContainerInfo(
         Mesos.ContainerInfo.Type.DOCKER, // Type
@@ -104,39 +59,11 @@ describe("Offers handlers tests", function () {
         )
     );
 
+    var task1;
 
-    util.inherits(SchedulerStub, EventEmitter);
-
-    before(function () {
-        scheduler.decline = function (offers, filters) {
-            console.log("Decline the offer");
-            accept = false;
-        }
-
-        scheduler.accept = function (offerId, operations, filters) {
-            console.log("Accept the offer");
-            accept = true;
-        }
-    });
-
-    it("Recive an offer but there are no pending tasks", function (done) {
-        scheduler.pendingTasks = [];
-        var logger = helpers.getLogger(null, null, "debug");
-        scheduler.logger = logger;
-
-        handlers["OFFERS"].call(scheduler, offers);
-
-        setTimeout(function () {
-            expect(accept).to.equal(false);
-            done();
-        }, 500); //timeout with an error in one second
-    });
-
-
-    it("Recive an offer while suitable task is pending", function (done) {
-
-        var task1 = {
-            "name": "My Task",
+    beforeEach(function () {
+        task1 = {
+            "name": "My Task-121",
             "task_id": {"value": "12220-3440-12532-my-task"},
             "containerInfo": ContainerInfo,
             "commandInfo": new Mesos.CommandInfo(
@@ -159,6 +86,87 @@ describe("Offers handlers tests", function () {
                 "disk": 10
             }
         };
+        offers = {
+            "type": "OFFERS",
+            "offers": [
+                {
+                    "id": {"value": "12214-23523-O235235"},
+                    "framework_id": {"value": "12124-235325-32425"},
+                    "agent_id": {"value": "12325-23523-S23523"},
+                    "hostname": "agent.host",
+                    "url": Url,
+                    "resources": [
+                        {
+                            "name": "cpus",
+                            "type": "SCALAR",
+                            "scalar": {"value": 1.1},
+                            "role": "*"
+                        },
+                        {
+                            "name": "mem",
+                            "role": "*",
+                            "type": "SCALAR",
+                            "scalar": {"value": 256}
+                        },
+                        {
+                            "name": "disk",
+                            "type": "SCALAR",
+                            "scalar": {
+                                "value": 10000
+                            }
+                        },
+                        {
+                            "name": "ports",
+                            "role": "*",
+                            "type": "RANGES",
+                            "ranges": {
+                                "range": [
+                                    {
+                                        "begin": 8080,
+                                        "end": 8090
+                                    },
+                                    {
+                                        "begin": 9000,
+                                        "end": 9019
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        };
+    });
+
+    util.inherits(SchedulerStub, EventEmitter);
+
+    before(function () {
+        scheduler.decline = function (offers, filters) {
+            console.log("Decline the offer");
+            accept = false;
+        };
+
+        scheduler.accept = function (offerId, operations, filters) {
+            console.log("Accept the offer");
+            accept = true;
+        };
+    });
+
+    it("Recive an offer but there are no pending tasks", function (done) {
+        scheduler.pendingTasks = [];
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.logger = logger;
+
+        handlers["OFFERS"].call(scheduler, offers);
+
+        setTimeout(function () {
+            expect(accept).to.equal(false);
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+
+    it("Recive an offer while suitable task is pending", function (done) {
 
         var logger = helpers.getLogger(null, null, "debug");
 
@@ -166,7 +174,7 @@ describe("Offers handlers tests", function () {
         scheduler.launchedTasks = [];
         scheduler.logger = logger;
         scheduler.frameworkId = "12124-235325-32425";
-        scheduler.options = {"frameworkName": "myfmw"}
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
 
         handlers["OFFERS"].call(scheduler, offers);
 
@@ -174,41 +182,171 @@ describe("Offers handlers tests", function () {
             expect(accept).to.equal(true);
             expect(scheduler.launchedTasks.length).to.equal(1);
             expect(scheduler.launchedTasks[0].runtimeInfo.agentId).to.equal("12325-23523-S23523");
+            expect(scheduler.launchedTasks[0].mesosName).to.equal("My Task-121");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+
+    it("Recive an offer while suitable task is pending - no serialNumberedTasks", function (done) {
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        task1.healthCheck = new Mesos.HealthCheck.HTTP(0, "/health", 200);
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": false};
+
+        handlers["OFFERS"].call(scheduler, offers);
+
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].runtimeInfo.agentId).to.equal("12325-23523-S23523");
+            expect(scheduler.launchedTasks[0].mesosName).to.equal("My Task");
             done();
         }, 500); //timeout with an error in one second
     });
 
     it("Recive an offer with insufficient ports", function (done) {
-        var task1 = {
-            "name": "My Task",
-            "task_id": {"value": "12220-3440-12532-my-task"},
-            "containerInfo": ContainerInfo,
-            "commandInfo": new Mesos.CommandInfo(
-                null, // URI
-                new Mesos.Environment([
-                    new Mesos.Environment.Variable("FOO", "BAR")
-                ]), // Environment
-                false, // Is shell?
-                null, // Command
-                null, // Arguments
-                null // User
-            ),
-            "portMappings": [
-                {"port": 8081, "protocol": "tcp"}
-            ],
-            "resources": {
-                "cpus": 0.2,
-                "mem": 128,
-                "ports": 12,
-                "disk": 10
-            }
-        };
+
+        task1.resources.ports = 50;
+
         var logger = helpers.getLogger(null, null, "debug");
         scheduler.pendingTasks = [task1];
         scheduler.launchedTasks = [];
         scheduler.logger = logger;
         scheduler.frameworkId = "12124-235325-32425";
-        scheduler.options = {"frameworkName": "myfmw"}
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true}
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(false);
+            expect(scheduler.launchedTasks.length).to.equal(0);
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(1);
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with no ports, with no disk", function (done) {
+        task1.resources.ports = 0;
+        task1.resources.disk = 0;
+        task1.resources.staticPorts = undefined;
+
+        var saved = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.saveTask = function (task) {
+            expect(saved).to.be.false;
+            saved = true;
+        };
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(saved).to.be.true;
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            done();
+        }, 500); //timeout with an error in one second
+    });
+    it("Recive an offer with static ports of one range", function (done) {
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8081, 8082];
+
+        var saved = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        task1.healthCheck = new Mesos.HealthCheck.HTTP(1, "/health", 200);
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.saveTask = function (task) {
+            expect(saved).to.be.false;
+            saved = true;
+        };
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(saved).to.be.true;
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("8081");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].value).to.equal("8082");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of one range and dynamic ports on the rest", function (done) {
+        task1.resources.ports = 31;
+        task1.resources.staticPorts = [8081, 8082];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("8081");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].value).to.equal("8082");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of one range and dynamic ports on the rest", function (done) {
+        task1.resources.ports = 31;
+        task1.resources.staticPorts = [8090, 9019];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("8090");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].value).to.equal("9019");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of one range and dynamic ports on the rest - fail", function (done) {
+        task1.resources.ports = 32;
+        task1.resources.staticPorts = [8090, 9019];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
         handlers["OFFERS"].call(scheduler, offers);
         setTimeout(function () {
             expect(accept).to.equal(false);
@@ -217,32 +355,197 @@ describe("Offers handlers tests", function () {
         }, 500); //timeout with an error in one second
     });
 
+    it("Recive an offer with static ports of two ranges", function (done) {
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8081, 9001];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables).to.have.lengthOf(4);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("8081");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].value).to.equal("9001");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of two ranges and dynamic ports that fill more than one range", function (done) {
+        task1.resources.ports = 31;
+        task1.resources.staticPorts = [8081,9001];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables).to.have.length.above(31);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("8081");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].value).to.equal("9001");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer unknown range resource", function (done) {
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8080,9001];
+        task1.commandInfo.environment = [];
+        offers.offers[0].resources[4] = {
+                            "name": "portsa",
+                            "role": "*",
+                            "type": "RANGES",
+                            "ranges": {
+                                "range": [
+                                    {
+                                        "begin": 8080,
+                                        "end": 8090
+                                    },
+                                    {
+                                        "begin": 9000,
+                                        "end": 9019
+                                    }
+                                ]
+                            }
+                        };
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables).to.have.lengthOf(3);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].value).to.equal("8080");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("9001");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("HOST");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with no environment - static ports", function (done) {
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8080,9001];
+        task1.commandInfo.environment = [];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables).to.have.lengthOf(3);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].value).to.equal("8080");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("9001");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("HOST");
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with no containerInfo - with lables - static ports", function (done) {
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8080,9001];
+        task1.commandInfo.environment = [];
+        task1.containerInfo = undefined;
+        task1.labels = new Mesos.Labels([new Mesos.Label("test1","data")]);
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(true);
+            expect(scheduler.launchedTasks.length).to.equal(1);/*
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables).to.have.lengthOf(3);
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].name).to.equal("PORT0");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[0].value).to.equal("8080");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].name).to.equal("PORT1");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[1].value).to.equal("9001");
+            expect(scheduler.launchedTasks[0].commandInfo.environment.variables[2].name).to.equal("HOST");*/
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of two ranges, decline", function (done) {
+
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8181, 9100];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": false};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(false);
+            expect(scheduler.launchedTasks.length).to.equal(0);
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(1);
+            done();
+        }, 500); //timeout with an error in one second
+    });
+
+    it("Recive an offer with static ports of two ranges, decline below", function (done) {
+
+        task1.resources.ports = 2;
+        task1.resources.staticPorts = [8079, 8999];
+
+        var logger = helpers.getLogger(null, null, "debug");
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": false};
+        scheduler.options.staticPorts = true;
+        handlers["OFFERS"].call(scheduler, offers);
+        setTimeout(function () {
+            expect(accept).to.equal(false);
+            expect(scheduler.launchedTasks.length).to.equal(0);
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(1);
+            done();
+        }, 500); //timeout with an error in one second
+    });
 
     it("Recive an offer while suitable task with runtimeInfo is pending", function (done) {
 
         var runtimeInfo = {agentId: "12345"}
-        var task1 = {
-            "name": "My Task",
-            "task_id": {"value": "12220-3440-12532-my-task"},
-            "containerInfo": ContainerInfo,
-            "runtimeInfo": runtimeInfo,
-            "commandInfo": new Mesos.CommandInfo(
-                null, // URI
-                new Mesos.Environment([
-                    new Mesos.Environment.Variable("FOO", "BAR")
-                ]), // Environment
-                false, // Is shell?
-                null, // Command
-                null, // Arguments
-                null // User
-            ),
-            "resources": {
-                "cpus": 0.2,
-                "mem": 128,
-                "ports": 2,
-                "disk": 10
-            }
-        };
+        task1.runtimeInfo = runtimeInfo;
 
         var logger = helpers.getLogger(null, null, "debug");
 
@@ -250,7 +553,8 @@ describe("Offers handlers tests", function () {
         scheduler.launchedTasks = [];
         scheduler.logger = logger;
         scheduler.frameworkId = "12124-235325-32425";
-        scheduler.options = {"frameworkName": "myfmw"}
+        scheduler.options = {"frameworkName": "myfmw", "serialNumberedTasks": true};
+        //scheduler.staticPorts = [];
 
         handlers["OFFERS"].call(scheduler, offers);
 
@@ -265,13 +569,62 @@ describe("Offers handlers tests", function () {
 
     it("Recive an offer while unsuitable task is pending", function (done) {
 
-        var task1 = {
-            "name": "My Task",
-            "task_id": {"value": "12220-3440-12532-my-task"},
+        task1.resources.mem = 1028;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        scheduler.pendingTasks = [task1];
+        scheduler.launchedTasks = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {"frameworkName": "myfmw"}
+
+        handlers["OFFERS"].call(scheduler, offers);
+
+        setTimeout(function () {
+            expect(accept).to.equal(false);
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(1);
+            done();
+        }, 500); //timeout with an error in one second
+    });
+});
+
+
+describe("Update handlers tests", function () {
+
+    var acknowleged;
+    var killed;
+    var runtimeInfo;
+    var task1;
+    var scheduler;
+
+    function SchedulerStub() {
+        // Inherit from EventEmitter
+        EventEmitter.call(this);
+        return this;
+    };
+
+    util.inherits(SchedulerStub, EventEmitter);
+
+    beforeEach(function () {
+        acknowleged = false;
+        killed = false;
+        runtimeInfo = {agentId: "12345", executorId: "5457"}
+        task1 = {
+            "name": "my-task",
+            "taskId": "12344-my-task",
+            "runtimeInfo": runtimeInfo,
             "commandInfo": new Mesos.CommandInfo(
                 null, // URI
                 new Mesos.Environment([
-                    new Mesos.Environment.Variable("FOO", "BAR")
+                    new Mesos.Environment.Variable("FOO", "BAR"),
+                    new Mesos.Environment.Variable("PORT5053252", "BAR"),
+                    new Mesos.Environment.Variable("PORT5", "BAR"),
+                    new Mesos.Environment.Variable("PORT5HAFDSA", "BAR"),
+                    new Mesos.Environment.Variable("1PORT3", "BAR"),
+                    new Mesos.Environment.Variable("0HOST", "BAR"),
+                    new Mesos.Environment.Variable("HOST1", "BAR"),
+                    new Mesos.Environment.Variable("HOST", "BAR") // 3 Variables need to be removed when restarting a task, 5 should be left
                 ]), // Environment
                 false, // Is shell?
                 null, // Command
@@ -286,83 +639,30 @@ describe("Offers handlers tests", function () {
             }
         };
 
-        var logger = helpers.getLogger(null, null, "debug");
+        scheduler = new SchedulerStub();
 
-        scheduler.pendingTasks = [task1];
-        scheduler.launchedTasks = [];
-        scheduler.logger = logger;
-        scheduler.frameworkId = "12124-235325-32425";
-        scheduler.options = {"frameworkName": "myfmw"}
+        /**
+         * Acknowledge a status update.
+         * @param {object} update The status update to acknowledge.
+         */
+        scheduler.acknowledge = function (update) {
 
-        handlers["OFFERS"].call(scheduler, offers);
+            if (!update.status.uuid) {
+                acknowleged = false;
+                return;
+            }
 
-        setTimeout(function () {
-            expect(accept).to.equal(false);
-            done();
-        }, 500); //timeout with an error in one second
-    });
-});
+            acknowleged = true;
+        };
 
+        scheduler.kill = function (taskId, agentId) {
+            killed = true
+        };
 
-describe("Update handlers tests", function () {
-
-    var acknowleged;
-    var killed;
-
-    beforeEach(function () {
-        acknowleged = false;
-        killed = false;
     });
 
 
-    function SchedulerStub() {
-        // Inherit from EventEmitter
-        EventEmitter.call(this);
-        return this;
-    };
 
-    var scheduler = new SchedulerStub();
-
-    /**
-     * Acknowledge a status update.
-     * @param {object} update The status update to acknowledge.
-     */
-    scheduler.acknowledge = function (update) {
-
-        if (!update.status.uuid) {
-            acknowleged = false;
-            return;
-        }
-
-        acknowleged = true;
-    };
-
-    scheduler.kill  = function (taskId, agentId) {
-        killed = true
-    };
-
-    var runtimeInfo = {agentId: "12345", executorId: "5457"}
-    var task1 = {
-        "name": "my-task",
-        "taskId": "12344-my-task",
-        "runtimeInfo": runtimeInfo,
-        "commandInfo": new Mesos.CommandInfo(
-            null, // URI
-            new Mesos.Environment([
-                new Mesos.Environment.Variable("FOO", "BAR")
-            ]), // Environment
-            false, // Is shell?
-            null, // Command
-            null, // Arguments
-            null // User
-        ),
-        "resources": {
-            "cpus": 0.2,
-            "mem": 1280,
-            "ports": 2,
-            "disk": 0
-        }
-    };
 
 
     it("Recive an update no uuid", function (done) {
@@ -396,7 +696,7 @@ describe("Update handlers tests", function () {
 
     });
 
-    it("Recive an update with uuid", function (done) {
+    it("Recive an update with uuid and message", function (done) {
 
         var logger = helpers.getLogger(null, null, "debug");
 
@@ -406,7 +706,8 @@ describe("Update handlers tests", function () {
                 "state": "TASK_RUNNING",
                 "source": "SOURCE_EXECUTOR",
                 "bytes": "uhdjfhuagdj63d7hadkf",
-                "uuid": "jhadf73jhakdlfha723adf"
+                "uuid": "jhadf73jhakdlfha723adf",
+                "message": "Update message from mesos"
             }
         };
 
@@ -457,12 +758,11 @@ describe("Update handlers tests", function () {
             "restartStates": ["TASK_FAILED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
         };
 
-        scheduler.options.useZk = true;
+        scheduler.options.useZk = false;
 
         handlers["UPDATE"].call(scheduler, update);
         setTimeout(function () {
             expect(scheduler.launchedTasks.length).to.equal(0);
-            expect(scheduler.taskHelper.deleteTask())
             done();
         }, 500); //timeout with an error in one second
 
@@ -503,7 +803,6 @@ describe("Update handlers tests", function () {
         handlers["UPDATE"].call(scheduler, update);
         setTimeout(function () {
             expect(scheduler.launchedTasks.length).to.equal(0);
-            expect(scheduler.taskHelper.deleteTask())
             done();
         }, 500); //timeout with an error in one second
 
@@ -519,9 +818,9 @@ describe("Update handlers tests", function () {
                 "state": "TASK_KILLED",
                 "source": "SOURCE_EXECUTOR",
                 "bytes": "uhdjfhuagdj63d7hadkf",
-                "uuid": "jhadf73jhakdlfha723adf",
+                "uuid": "jhadf73jhakdlfha723adf"/*,
                 "executor_id": {"value": "12344-my-executor"},
-                "agent_id": {"value": "12344-my-agent"}
+                "agent_id": {"value": "12344-my-agent"}*/
             }
         };
 
@@ -537,6 +836,134 @@ describe("Update handlers tests", function () {
         handlers["UPDATE"].call(scheduler, update);
         setTimeout(function () {
             expect(scheduler.pendingTasks.length).to.equal(1);
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(5);
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
+
+    it("Recive an update for launched task to be killed - restart and delete from zk - no environment", function (done) {
+
+        var deleted = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_KILLED",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf"/*,
+                "executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}*/
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        task1.commandInfo.environment.variables = [];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_FAILED", "TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.deleteTask = function (task) {
+            expect(deleted).to.be.false;
+            deleted = true;
+        };
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(scheduler.pendingTasks.length).to.equal(1);
+            expect(deleted).to.be.true;
+            expect(scheduler.pendingTasks[0].commandInfo.environment.variables).to.have.lengthOf(0);
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
+
+    it("Recive an update for launched task to be killed - restarting and delete from zk - restartStates", function (done) {
+
+        var deleted = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_KILLED",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf"/*,
+                "executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}*/
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_FAILED", "TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.deleteTask = function (task) {
+            expect(deleted).to.be.false;
+            deleted = true;
+        };
+
+        task1.runtimeInfo.restarting = true;
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(scheduler.pendingTasks.length).to.equal(0);
+            expect(deleted).to.be.true;
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
+
+    it("Recive an update for launched task to be killed - restarting without zk", function (done) {
+
+        var deleted = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_KILLED",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf"/*,
+                "executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}*/
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1, {"taskId": "124313-fdsf-fsa"}];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_FAILED", "TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = false;
+
+        task1.runtimeInfo.restarting = true;
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(scheduler.pendingTasks.length).to.equal(0);
+            expect(deleted).to.be.false;
             done();
         }, 500); //timeout with an error in one second
 
@@ -575,6 +1002,139 @@ describe("Update handlers tests", function () {
 
     });
 
+    it("Recive an update for launched task is running", function (done) {
+
+        var saved = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_RUNNING",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf",
+                //"executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        task1.runtimeInfo.state = "TASK_STAGING";
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.saveTask = function (task) {
+            expect(saved).to.be.false;
+            saved = true;
+        };
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(saved).to.be.true;
+            expect(scheduler.launchedTasks[0].runtimeInfo.state).to.equal("TASK_RUNNING");
+            expect(scheduler.launchedTasks[0].runtimeInfo.startTime).to.be.above(1484200000000);
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
+
+    it("Recive an update for launched task is running - different info available", function (done) {
+
+        var saved = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_RUNNING",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf",
+                //"executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        task1.runtimeInfo.state = "TASK_STAGING";
+        var originalStartTime = Date.now();
+        task1.runtimeInfo.startTime = originalStartTime;
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.saveTask = function (task) {
+            expect(saved).to.be.false;
+            saved = true;
+        };
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(saved).to.be.true;
+            expect(scheduler.launchedTasks[0].runtimeInfo.state).to.equal("TASK_RUNNING");
+            expect(scheduler.launchedTasks[0].runtimeInfo.startTime).to.equal(originalStartTime);
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
+
+    it("Recive an update for launched task is running - no runtimeInfo available", function (done) {
+
+        var saved = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12344-my-task"},
+                "state": "TASK_RUNNING",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf",
+                "executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"}
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        task1.runtimeInfo = {};
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.saveTask = function (task) {
+            expect(saved).to.be.false;
+            saved = true;
+        };
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(saved).to.be.true;
+            expect(scheduler.launchedTasks[0].runtimeInfo.state).to.equal("TASK_RUNNING");
+            expect(scheduler.launchedTasks[0].runtimeInfo.startTime).to.be.above(1484200000000);
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
 
     it("Recive an update after reconciliation - no delete", function (done) {
 
@@ -612,6 +1172,50 @@ describe("Update handlers tests", function () {
 
     });
 
+    it("Recive an update after reconciliation - (no kill unknown tasks) cleanup from zookeeper", function (done) {
+
+        var deleted = false;
+
+        var logger = helpers.getLogger(null, null, "debug");
+
+        var update = {
+            "status": {
+                "task_id": {"value": "12345-my-task"},
+                "state": "TASK_FAILED",
+                "source": "SOURCE_EXECUTOR",
+                "bytes": "uhdjfhuagdj63d7hadkf",
+                "uuid": "jhadf73jhakdlfha723adf",
+                "executor_id": {"value": "12344-my-executor"},
+                "agent_id": {"value": "12344-my-agent"},
+                "reason": "REASON_RECONCILIATION"
+            }
+        };
+
+        scheduler.pendingTasks = [];
+        scheduler.launchedTasks = [task1];
+        scheduler.logger = logger;
+        scheduler.frameworkId = "12124-235325-32425";
+        scheduler.options = {
+            "frameworkName": "myfmw",
+            "restartStates": ["TASK_KILLED", "TASK_LOST", "TASK_ERROR", "TASK_FINISHED"]
+        };
+        scheduler.options.useZk = true;
+        scheduler.taskHelper = {};
+        scheduler.taskHelper.deleteTask = function (task) {
+            expect(deleted).to.be.false;
+            deleted = true;
+        };
+
+        scheduler.options.killUnknownTasks = false;
+
+        handlers["UPDATE"].call(scheduler, update);
+        setTimeout(function () {
+            expect(killed).to.equal(false);
+            expect(deleted).to.be.true;
+            done();
+        }, 500); //timeout with an error in one second
+
+    });
 
     it("Recive an update after reconciliation - delete", function (done) {
 

--- a/tests/taskHealthHelper.test.js
+++ b/tests/taskHealthHelper.test.js
@@ -1,0 +1,519 @@
+/*global describe, before, beforeEach, after, afterEach, it
+*/
+/*jslint
+this: true,
+es6: true,
+node: true
+*/
+
+"use strict";
+const fs = require("fs");
+
+var Scheduler = require("../").Scheduler;
+var http = require("http");
+
+var TaskHealthHelper = require("../lib/taskHealthHelper");
+
+// Testing require
+var expect = require('chai').expect;
+var sinon = require("sinon");
+var MockReq = require("mock-req");
+var MockRes = require("mock-res");
+
+describe("Vault Health Checker", function () {
+    var sandbox;
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+    afterEach(function () {
+        sandbox.restore();
+    });
+    it("No tasks no URL (fail)", function () {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        try {
+            healthCheck = new TaskHealthHelper(scheduler, {});
+        } catch (error) {
+            expect(error).to.be.an.error;
+        }
+        expect(healthCheck).to.be.undefined;
+    });
+    it("No tasks default options", function () {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+        this.checkInstance = sandbox.stub(healthCheck, "checkRunningInstances");
+        healthCheck.setupHealthCheck();
+        expect(this.checkInstance.called).to.be.false;
+    });
+    it("No tasks, no new default options", function () {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck = TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+        expect(healthCheck).to.be.an("object");
+    });
+    it("No tasks short interval", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok", "interval": 0.2});
+            self.checkInstance = sandbox.stub(healthCheck, "checkRunningInstances");
+            healthCheck.setupHealthCheck();
+        });
+        setTimeout(function() {
+            expect(self.checkInstance.called).to.be.true;
+            expect(self.checkInstance.callCount).to.be.at.least(2);
+            done();
+        }, 600);
+    });
+    it("Setup and stop", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok", "interval": 0.2});
+            self.checkInstance = sandbox.stub(healthCheck, "checkRunningInstances");
+            healthCheck.setupHealthCheck();
+            healthCheck.stopHealthCheck();
+        });
+        setTimeout(function() {
+            expect(self.checkInstance.called).to.be.false;
+            done();
+        }, 400);
+    });
+    it("Stop no setup", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok", "interval": 0.2});
+            self.checkInstance = sandbox.stub(healthCheck, "checkRunningInstances");
+            healthCheck.stopHealthCheck();
+        });
+        setTimeout(function() {
+            expect(self.checkInstance.called).to.be.false;
+            done();
+        }, 400);
+    });
+    it("Stop no setup", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok", "interval": 0.2});
+            self.checkInstance = sandbox.stub(healthCheck, "checkRunningInstances");
+            healthCheck.stopHealthCheck();
+        });
+        setTimeout(function() {
+            expect(self.checkInstance.called).to.be.false;
+            done();
+        }, 400);
+    });
+    it("checkRunningInstances", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            self.checkInstance = sandbox.stub(healthCheck, "checkInstance");
+            scheduler.launchedTasks = [{task:"name"},{task:"name2"}];
+            healthCheck.checkRunningInstances();
+            expect(self.checkInstance.called).to.be.true;
+            expect(self.checkInstance.callCount).to.be.equal(2);
+            done();
+        });
+    });
+    it("checkRunningInstances - prefix", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"propertyPrefix": "me", url: "/v1/sys/health?standbyok"});
+            self.checkInstance = sandbox.stub(healthCheck, "checkInstance");
+            scheduler.launchedTasks = [{task:"name"},{task:"name2"}];
+            healthCheck.checkRunningInstances();
+            expect(self.checkInstance.called).to.be.true;
+            expect(self.checkInstance.callCount).to.be.equal(2);
+            done();
+        });
+    });
+    it("checkInstance pass", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        var req = new MockReq({method: "GET"});
+        var task = {"name": "vault-35", "runtimeInfo": {"state": "TASK_RUNNING", "network": {"hostname": "task1", "ports": ["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"additionalProperties": [{"name": "sealed", "inverse": false}], url: "/v1/sys/health?standbyok", "taskNameFilter": "^vault-[0-9]+$"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(0);
+            expect(task.runtimeInfo.healthy).to.be.true;
+            expect(task.runtimeInfo.sealed).to.be.true;
+            done();
+        });
+    });
+    it("checkInstance pass - property inverse", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        var req = new MockReq({method: "GET"});
+        var task = {"name": "vault-35", "runtimeInfo": {"state": "TASK_RUNNING", "network": {"hostname": "task1", "ports": ["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"additionalProperties": [{"name": "sealed", "inverse": true}], url: "/v1/sys/health?standbyok", "taskNameFilter": "^vault-[0-9]+$"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(0);
+            expect(task.runtimeInfo.healthy).to.be.true;
+            expect(task.runtimeInfo.sealed).to.be.false;
+            done();
+        });
+    });
+    it("checkInstance pass - property inverse - with prefix ", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        var req = new MockReq({method: "GET"});
+        var task = {"name": "vault-35", "runtimeInfo": {"state": "TASK_RUNNING", "network": {"hostname": "task1", "ports": ["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"propertyPrefix": "me", "additionalProperties": [{"name": "sealed", "inverse": true}], url: "/v1/sys/health?standbyok", "taskNameFilter": "^vault-[0-9]+$"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(0);
+            expect(task.runtimeInfo.mehealthy).to.be.true;
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(task.runtimeInfo.sealed).to.be.false;
+            done();
+        });
+    });
+    it("checkInstance invalid task state", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        var req = new MockReq({ method: "GET" });
+        var task = {"runtimeInfo":{"state": "TASK_STAGING", "network":{"hostname": "task1","ports":["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.false;
+            expect(self.healthRequestCreate.callCount).to.be.equal(0);
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("checkInstance invalid task - missing hostname", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        var req = new MockReq({ method: "GET" });
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"ports":["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.false;
+            expect(self.healthRequestCreate.callCount).to.be.equal(0);
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("checkInstance http 500", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var res = new MockRes();
+        res.writeHead(500);
+        var req = new MockReq({ method: "GET" });
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.callsArgWith(1, res).returns(req);
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.setCheckFailed.called).to.be.true;
+            expect(self.setCheckFailed.callCount).to.be.equal(1);
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("checkInstance connection error", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var req = new MockReq({ method: "GET" });
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.returns(req);
+        scheduler.on("ready", function () {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            req.emit("error", new Error());
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.setCheckFailed.called).to.be.true;
+            expect(self.setCheckFailed.callCount).to.be.equal(1);
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("checkInstance connection error - prefix", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var self = this;
+        var req = new MockReq({ method: "GET" });
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        self.httpRequest = sandbox.stub(http, "request");
+        this.httpRequest.returns(req);
+        scheduler.on("ready", function () {
+            healthCheck = new TaskHealthHelper(scheduler, {"propertyPrefix": "me", url: "/v1/sys/health?standbyok"});
+            self.healthRequestCreate = sandbox.stub(healthCheck, "healthRequestCreate");
+            self.setCheckFailed = sandbox.stub(healthCheck, "setCheckFailed");
+            healthCheck.checkInstance(task);
+            req.emit("error", new Error());
+            expect(self.healthRequestCreate.called).to.be.true;
+            expect(self.setCheckFailed.called).to.be.true;
+            expect(self.setCheckFailed.callCount).to.be.equal(1);
+            expect(self.healthRequestCreate.callCount).to.be.equal(1);
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("setCheckFailed - once on new task", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        scheduler.on("ready", function () {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            done();
+        });
+    });
+    it("setCheckFailed - 3 times on new task", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = false;
+        scheduler.on("ready", function () {
+            healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted = true;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(emitted).to.be.false;
+            done();
+        });
+    });
+    it("setCheckFailed - 4 times on new task - no setUnhealthy", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = false;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"additionalProperties": [{"name": "sealed", "inverse": true}], url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted = true;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(emitted).to.be.false;
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(4);
+            expect(task.runtimeInfo.healthy).to.be.false;
+            expect(task.runtimeInfo.sealed).to.be.undefined;
+            expect(emitted).to.be.true;
+            done();
+        });
+    });
+    it("setCheckFailed - 4 times on new task", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = false;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"additionalProperties": [{"setUnhealthy": true, "name": "sealed", "inverse": true}], url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted = true;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(emitted).to.be.false;
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(4);
+            expect(task.runtimeInfo.healthy).to.be.false;
+            expect(task.runtimeInfo.sealed).to.be.true;
+            expect(emitted).to.be.true;
+            done();
+        });
+    });
+    it("setCheckFailed - 4 times on new task - prefix", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = false;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"propertyPrefix": "me", "additionalProperties": [{"setUnhealthy": true, "name": "sealed", "inverse": true}], url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted = true;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            expect(emitted).to.be.false;
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(4);
+            expect(task.runtimeInfo.mehealthy).to.be.false;
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(task.runtimeInfo.sealed).to.be.true;
+            expect(emitted).to.be.true;
+            done();
+        });
+    });
+    it("setCheckFailed - 5 times on new task", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = 0;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"additionalProperties": [{"setUnhealthy": true, "name": "sealed", "inverse": false}], url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted += 1;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(emitted).to.be.equal(0);
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(4);
+            expect(task.runtimeInfo.healthy).to.be.false;
+            expect(emitted).to.equal(1);
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.checkFailCount).to.be.equal(5);
+            expect(task.runtimeInfo.healthy).to.be.false;
+            expect(task.runtimeInfo.sealed).to.be.false;
+            expect(emitted).to.equal(2);
+            done();
+        });
+    });
+    it("setCheckFailed - 5 times on new task - prefix", function (done) {
+        var scheduler = new Scheduler({useZk: false, logging: {level: "debug"}, "frameworkName": "testFramework"});
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+        var emitted = 0;
+        scheduler.on("ready", function() {
+            healthCheck = new TaskHealthHelper(scheduler, {"propertyPrefix": "me", "additionalProperties": [{"setUnhealthy": true, "name": "sealed", "inverse": false}], url: "/v1/sys/health?standbyok"});
+            scheduler.on("task_unhealthy", function (task) {
+                emitted += 1;
+            });
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(1);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(2);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(3);
+            expect(task.runtimeInfo.mehealthy).to.be.an("undefined");
+            expect(emitted).to.be.equal(0);
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(4);
+            expect(task.runtimeInfo.mehealthy).to.be.false;
+            expect(emitted).to.equal(1);
+            healthCheck.setCheckFailed(task);
+            expect(task.runtimeInfo.mecheckFailCount).to.be.equal(5);
+            expect(task.runtimeInfo.mehealthy).to.be.false;
+            expect(task.runtimeInfo.sealed).to.be.false;
+            expect(task.runtimeInfo.checkFailCount).to.be.an("undefined");
+            expect(task.runtimeInfo.healthy).to.be.an("undefined");
+            expect(emitted).to.equal(2);
+            done();
+        });
+    });
+    it("healthRequestCreate", function () {
+        var scheduler = {};
+        var healthCheck;
+        var task = {"runtimeInfo":{"state": "TASK_RUNNING", "network":{"hostname": "task1","ports":["23142"]}}};
+
+        healthCheck = new TaskHealthHelper(scheduler, {url: "/v1/sys/health?standbyok"});
+
+        var template = healthCheck.healthRequestCreate(task.runtimeInfo.network.hostname, task.runtimeInfo.network.ports[0]);
+        expect(task.runtimeInfo.network.hostname).to.be.equal(template.host);
+        expect(task.runtimeInfo.network.ports[0]).to.be.equal(template.port);
+        expect(template.method).to.be.equal("GET");
+
+    });
+});

--- a/tests/taskHelper.test.js
+++ b/tests/taskHelper.test.js
@@ -186,9 +186,9 @@ describe("Load tasks from Zk:", function () {
             cb(null, ["one", "two", "three"], 1);
         });
 
-        var task1 = {name: "/task1", state: "TASK_RUNNING", taskId: "1", runtimeInfo: {agentId: "12345"}};
-        var task2 = {name: "/task2", state: "TASK_RUNNING", taskId: "2", runtimeInfo: {agentId: "12346"}};
-        var task3 = {name: "/task3", state: "TASK_FINISHED", taskId: "3", runtimeInfo: {agentId: "12446"}};
+        var task1 = {name: "/task1", taskId: "1", runtimeInfo: {agentId: "12345", state: "TASK_RUNNING"}};
+        var task2 = {name: "/task2", taskId: "2", runtimeInfo: {agentId: "12346", state: "TASK_RUNNING"}};
+        var task3 = {name: "/task3", taskId: "3", runtimeInfo: {agentId: "12446", state: "TASK_FINISHED"}};
 
         sandbox.stub(zkClient, "getData", function (path, cb) {
             if (path.includes("one")) {
@@ -245,8 +245,8 @@ describe("Load tasks from Zk:", function () {
         });
 
         var deleted = false;
-        var task1 = {name: "/task1", state: "TASK_RUNNING", taskId: "1", runtimeInfo: {agentId: "12345"}};
-        var task2 = {name: "/task2", state: "TASK_RUNNING", taskId: "2", runtimeInfo: {agentId: "12346"}};
+        var task1 = {name: "/task1", taskId: "1", runtimeInfo: {agentId: "12345", state: "TASK_RUNNING"}};
+        var task2 = {name: "/task2", taskId: "2", runtimeInfo: {agentId: "12346", state: "TASK_RUNNING"}};
 
         sandbox.stub(zkClient, "getData", function (path, cb) {
             if (path.includes("one")) {

--- a/tests/taskHelper.test.js
+++ b/tests/taskHelper.test.js
@@ -180,26 +180,34 @@ describe("Load tasks from Zk:", function () {
         expect(schedulerStub.killTasks.length).to.equal(2);
     });
     it("Succeed to load tasks and found in pending (should restore)", function (done) {
+        var deleted = false;
         zkClient.getChildren.restore();
         sandbox.stub(zkClient, "getChildren", function (path, cb) {
-            cb(null, ["one", "two"], 1);
+            cb(null, ["one", "two", "three"], 1);
         });
 
-        var task1 = {name: "/task1", taskId: "1", runtimeInfo: {agentId: "12345"}};
-        var task2 = {name: "/task2", taskId: "2", runtimeInfo: {agentId: "12346"}};
+        var task1 = {name: "/task1", state: "TASK_RUNNING", taskId: "1", runtimeInfo: {agentId: "12345"}};
+        var task2 = {name: "/task2", state: "TASK_RUNNING", taskId: "2", runtimeInfo: {agentId: "12346"}};
+        var task3 = {name: "/task3", state: "TASK_FINISHED", taskId: "3", runtimeInfo: {agentId: "12446"}};
 
         sandbox.stub(zkClient, "getData", function (path, cb) {
             if (path.includes("one")) {
                 cb(null, JSON.stringify(task1), 1);
-            } else {
+            } else if (path.includes("two")) {
                 cb(null, JSON.stringify(task2), 1);
+            } else {
+                cb(null, JSON.stringify(task3), 1);
             }
         });
 
+        sandbox.stub(zkClient, "remove", function (path, cb) {
+            cb(null, null);
+            deleted = true;
+        });
         var logger = helpers.getLogger(null, null, "info");
         var schedulerStub = new SchedulerStub();
 
-        schedulerStub.pendingTasks = [task1, task2];
+        schedulerStub.pendingTasks = [task1, task2, task3];
         schedulerStub.killTasks = [];
         schedulerStub.launchedTasks = [];
         schedulerStub.reconcileTasks = [];
@@ -223,6 +231,7 @@ describe("Load tasks from Zk:", function () {
         }, 100); //timeout with an error in one second
 
         expect(eventFired).to.equal(true);
+        expect(deleted).to.be.true;
 
         // check that tasks were killed
         expect(schedulerStub.killTasks.length).to.equal(0);
@@ -236,8 +245,8 @@ describe("Load tasks from Zk:", function () {
         });
 
         var deleted = false;
-        var task1 = {name: "/task1", taskId: "1", runtimeInfo: {agentId: "12345"}};
-        var task2 = {name: "/task2", taskId: "2", runtimeInfo: {agentId: "12346"}};
+        var task1 = {name: "/task1", state: "TASK_RUNNING", taskId: "1", runtimeInfo: {agentId: "12345"}};
+        var task2 = {name: "/task2", state: "TASK_RUNNING", taskId: "2", runtimeInfo: {agentId: "12346"}};
 
         sandbox.stub(zkClient, "getData", function (path, cb) {
             if (path.includes("one")) {


### PR DESCRIPTION
Support for static ports definitions, a fix of issues reconnecting to master, an option to remove serial number from tasks (serial numbers added for ZK persistency).
A task launched event, support for task graceful restart (on the "boilerplate" side) by launching a duplicate and killing the task after the duplicate is healthy, task health check support (both in Mesos and in the framework itself with events), fixed an issue with large event messages not handled properly, fix an issue with old tasks staying in the ZK and loaded.